### PR TITLE
Dictionary map

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,19 @@ NSDictionary *dict = @{ @"one" : @1, @"two" : @2, @"three" : @3 };
 // Value: 1
 // Value: 2
 // Value: 3
+
+NSDictionary *errors = @{
+    @"username" : @[ @"already taken" ],
+    @"password" : @[ @"is too short (minimum is 8 characters)", @"not complex enough" ],
+    @"email" : @[ @"can't be blank" ];
+};
+
+[errors map:^(id attribute, id reasons) {
+    return NSStringWithFormat(@"%@ %@", attribute, [reasons join:@", "]);
+}];
+// username already taken
+// password is too short (minimum is 8 characters), not complex enough
+// email can't be blank
 ```
 
 #### NSString additions

--- a/SampleProject/SampleProjectTests/NSDictionaryTests.m
+++ b/SampleProject/SampleProjectTests/NSDictionaryTests.m
@@ -51,6 +51,23 @@ describe(@"Iterators", ^{
         }];  
     });
     
+    it(@"iterates all keys when mapping", ^{
+        NSArray *mapped = [sampleDict map:^id(id key, id value) {
+            counter ++;
+            return key;
+        }];
+        
+        [[mapped should] equal:sampleDict.allKeys];
+    });
+
+    it(@"iterates all values when mapping", ^{
+        NSArray *mapped = [sampleDict map:^id(id key, id value) {
+            counter ++;
+            return value;
+        }];
+        
+        [[mapped should] equal:sampleDict.allValues];
+    });
 });
 
 SPEC_END

--- a/src/NSDictionary+ObjectiveSugar.h
+++ b/src/NSDictionary+ObjectiveSugar.h
@@ -13,5 +13,6 @@
 - (void)each:(void (^)(id key, id value))block;
 - (void)eachKey:(void (^)(id key))block;
 - (void)eachValue:(void (^)(id value))block;
+- (NSArray *)map:(id (^)(id key, id value))block;
 
 @end

--- a/src/NSDictionary+ObjectiveSugar.m
+++ b/src/NSDictionary+ObjectiveSugar.m
@@ -28,4 +28,15 @@
     }];
 }
 
+- (NSArray *)map:(id (^)(id key, id value))block {
+    NSMutableArray *array = [NSMutableArray array];
+    
+    [self enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+        id object = block(key, obj);
+        [array addObject:object];
+    }];
+    
+    return array;
+}
+
 @end


### PR DESCRIPTION
I was working with `ActiveRecord` validation errors and needed to turn them into a string, `NSDictionary#map` seemed like a reasonable solution. See Ruby `Hash#map` (inherited from [`Enumerable`](http://www.ruby-doc.org/core-1.9.3/Enumerable.html#method-i-map)) for a direct comparision.

**JSON Response**

``` JSON
{
  "username" : [ "already taken" ],
  "password" : [ "is too short (minimum is 8 characters)", "not complex enough" ],
  "email" : [ "can't be blank" ]
}
```

**Ruby**

``` Ruby
errors map do |attribute, reason|
  "%s %s" % [ attribute, reasons.join(", ") ]
end
```

**Objective-C**

``` Objective-C
NSArray* sentences = [errors map:^(id attribute, id reasons) {
    return NSStringWithFormat(@"%@ %@", attribute, [reasons join:@", "]);
}];

[sentences join:@"; "];
// username already taken; password is too short (minimum is 8 characters), not complex enough; email can't be blank
```

N.B. I'm only a recent adopter of ObjectiveSugar but I fell in love immediately, thank you for such a lovely library.
