### PR TITLE
pass ONLY_ACTIVE_ARCH=NO to xctool, hopefully this fixes `make test`

### DIFF
--- a/Example/Makefile
+++ b/Example/Makefile
@@ -4,7 +4,7 @@ DEFAULT_SCHEME=$(PROJECT_NAME)
 
 test:
 	xctool -workspace $(WORKSPACE) -scheme $(DEFAULT_SCHEME) \
-		-sdk iphonesimulator clean test
+		-sdk iphonesimulator ONLY_ACTIVE_ARCH=NO clean test
 
 remove_pods:
 	rm -rf Pods


### PR DESCRIPTION
I don't fully understand _why_ this is needed.  I think it's a
shortcoming in xctool, but we don't have it figured out yet.

I find I have to add this whenever I'm running application tests.

Let's see what Travis says....
