### PR TITLE
Fix some typo and mistake in README. Change NSArray's objectForKeyedSubscript: action

### DIFF
--- a/Classes/NSArray+ObjectiveSugar.h
+++ b/Classes/NSArray+ObjectiveSugar.h
@@ -29,8 +29,7 @@
 /**
  Allow subscripting to fetch elements within the specified range
  
- @param An NSValue wrapping an NSRange struct or an NSString with valid 
- range components, ie: @"1..3" specifying the range of elements to return
+ @param An NSValue wrapping an NSRange struct or an NSString with valid range components. If it is an NSString, it will be parsed to an NSRange. eg. @"1..3" specifying the range from 1 to 3. @"1...3" specifying the range from 1 to 2 (exclude the end value 3). Other strinig which contains two int values (@"1,3") will be parsed as range's location and length.
  
  @return An array with all the elements within the specified range
  */

--- a/Classes/NSArray+ObjectiveSugar.m
+++ b/Classes/NSArray+ObjectiveSugar.m
@@ -8,6 +8,7 @@
 
 #import "NSArray+ObjectiveSugar.h"
 #import "NSMutableArray+ObjectiveSugar.h"
+#import "NSString+ObjectiveSugar.h"
 
 @implementation NSArray (ObjectiveSugar)
 
@@ -25,7 +26,13 @@
 - (id)objectForKeyedSubscript:(id <NSCopying>)key {
     NSRange range;
     if ([(id)key isKindOfClass:[NSString class]]) {
-        range = NSRangeFromString((NSString *)key);
+        NSString *keyString = (NSString *)key;
+        range = NSRangeFromString(keyString);
+        if ([keyString containsString:@"..."]) {
+            range = NSMakeRange(range.location, range.length - range.location);
+        } else if ([keyString containsString:@".."]) {
+            range = NSMakeRange(range.location, range.length - range.location + 1);
+        }
     } else if ([(id)key isKindOfClass:[NSValue class]]) {
         range = [((NSValue *)key) rangeValue];
     } else {

--- a/Example/ObjectiveSugarTests/NSArrayCategoriesTests.m
+++ b/Example/ObjectiveSugarTests/NSArrayCategoriesTests.m
@@ -124,7 +124,15 @@ describe(@"NSArray categories", ^{
         });
         
         it(@"returns an array containing the elements at the specified range when passing a string that contains a parsable range", ^{
-            [[oneToTen[@"2..5"] should] equal:@[@3, @4, @5, @6, @7]];
+            [[oneToTen[@"2,5"] should] equal:@[@3, @4, @5, @6, @7]];
+        });
+        
+        it(@"returns an array containing the elements at the specified range when passing a string that indicates an inclusive range", ^{
+            [[oneToTen[@"2..5"] should] equal:@[@3, @4, @5, @6]];
+        });
+        
+        it(@"returns an array containing the elements at the specified range when passing a string that indicates an inclusive range but excludes the end value", ^{
+            [[oneToTen[@"2...5"] should] equal:@[@3, @4, @5]];
         });
         
         it(@"returns an empty array when passing an invalid or empty range", ^{

--- a/README.md
+++ b/README.md
@@ -113,13 +113,22 @@ NSArray *numbers = @[ @5, @2, @7, @1 ];
 #### NSArray only
 ``` objc
 
-NSArray *indices = @[@1, @2, @3, @4, @5];
-indices[@"1..3"];
-// [@2, @3, @4]
+NSArray *indices = @[@1, @2, @3, @4, @5, @6];
+indices[@"2..4"];
+// index from 2 to 4
+// [@3, @4, @5]
 
-NSValue *range = [NSValue valueWithRange:NSMakeRange(1, 3)];
+indices[@"2…4"];
+// index from 2 to 4 (excluded)
+// [@3, @4]
+
+indices[@"2,4"];
+// range location: 2, length: 4
+// [@3, @4, @5, @6]
+
+NSValue *range = [NSValue valueWithRange:NSMakeRange(2, 4)];
 indices[range];
-// [@2, @3, @4]
+// [@3, @4, @5, @6]
 
 NSArray *fruits = @[ @"banana", @"mango", @"apple", @"pear" ];
 


### PR DESCRIPTION
Change `objectForKeyedSubscript:` of NSArray from simply range make to a ruby-like range literals. It make little sense by using a ruby syntax of range (..) but doing something like making NSRange with location and length. It might be a confusing, especially this syntax is designed to simulate some ruby syntax.

Using '..' run from the beginning to the end inclusively, and '…' for exclude the end value. For making range from string, using 'x,y' might be a good idea.

Please be caution 001ee18 will broke the `objectForKeyedSubscript:` api, but I believe it worth to change it earlier. bfbb414 is just fix a mistake in readme file.
