### PR TITLE
Documentation comments for NSString additions

### DIFF
--- a/Classes/NSSet+ObjectiveSugar.m
+++ b/Classes/NSSet+ObjectiveSugar.m
@@ -7,6 +7,7 @@
 //
 
 #import "NSSet+ObjectiveSugar.h"
+#import "NSArray+ObjectiveSugar.h"
 
 @implementation NSSet (ObjectiveSugar)
 

--- a/Classes/NSString+ObjectiveSugar.h
+++ b/Classes/NSString+ObjectiveSugar.h
@@ -12,14 +12,42 @@ NSString *NSStringWithFormat(NSString *format, ...) NS_FORMAT_FUNCTION(1,2);
 
 @interface NSString(ObjectiveSugar)
 
+/**
+ Returns an array containing substrings from the receiver that have been divided by a whitespace delimiter
+ 
+ @return An array containing substrings that have been divided by a whitespace delimiter
+ */
 - (NSArray *)split;
+
+
+/**
+ Returns an array containing substrings from the receiver that have been divided by a given delimiter
+ 
+ @param delimiter The delimiter string
+ @return An array containing substrings that have been divided by delimiter
+ */
 - (NSArray *)split:(NSString *)delimiter;
 
+
+/**
+ Returns a new string made by converting a snake_case_string to CamelCaseString
+ 
+ @return A string made by converting a snake_case_string to CamelCaseString
+ */
 - (NSString *)camelCase;
+
+
+/**
+ Returns a Boolean value that indicates whether a given string is a substring of the receiver
+ 
+ @return YES if 'string' is a substring of the receiver, otherwise NO
+ */
 - (BOOL)containsString:(NSString *)string;
+
 
 /**
  Returns a new string made by removing whitespaces and newlines from both ends of the receiver
+ 
  @return A string without trailing or leading whitespaces and newlines
  */
 - (NSString *)strip;


### PR DESCRIPTION
Hi there,
I've added some doc comments for the rest of NSString's additions (tried to keep the coding style of existing doc plus a coherent vocabulary with Apple's relevant method documentation). I've also issued a little fix for a warning (NSSet's `-sample` was sending a `-sample` message to NSArray without an import of the category).

Cheers!
