### PR TITLE
fixes #52

### DIFF
--- a/Classes/NSString+ObjectiveSugar.m
+++ b/Classes/NSString+ObjectiveSugar.m
@@ -32,16 +32,14 @@ NSString *NSStringWithFormat(NSString *formatString, ...) {
 @implementation NSString(Additions)
 
 - (NSArray *)split {
-    return [self split:@" "];
-}
-
-- (NSArray *)split:(NSString *)delimiter {
-    NSArray *result = [self componentsSeparatedByCharactersInSet:
-                            [NSCharacterSet characterSetWithCharactersInString:delimiter]];
-
+    NSArray *result = [self componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     return [result select:^BOOL(NSString *string) {
         return string.length > 0;
     }];
+}
+
+- (NSArray *)split:(NSString *)delimiter {
+    return [self componentsSeparatedByString:delimiter];
 }
 
 - (NSString *)camelCase {

--- a/Example/ObjectiveSugarTests/NSStringTests.m
+++ b/Example/ObjectiveSugarTests/NSStringTests.m
@@ -25,13 +25,17 @@ describe(@"Additions", ^{
     NSString *sentence = @"Jane Doe's going    in a shop,and,yeah;";
 
     it(@"-split splits by whitespace", ^{
-        [[[sentence split] should] equal:@[@"Jane", @"Doe's", @"going", @"in", @"a", @"shop,and,yeah;"]];
+        [[[@" the\r\nquick brown\t \tfox\n" split] should] equal:@[@"the", @"quick", @"brown", @"fox"]];
     });
     
     it(@"-split: splits with given delimiter", ^{
         [[[sentence split:@","] should] equal:@[@"Jane Doe's going    in a shop", @"and", @"yeah;"]];
     });
-    
+
+    it(@"-split: splits with delimiter string, not just a char", ^{
+        [[[@"one / two / three" split:@" / "] should] equal:@[@"one", @"two", @"three"]];
+    });
+
     it(@"contains string", ^{
         [[@([sentence containsString:@"jane doe"]) should] beTrue];
     });


### PR DESCRIPTION
I fixed split:delim. I had to change plain old split a bit since the old "whitespace split" behavior was counting on the broken split:delim. While I was at it I made plain old split use ALL whitespace as delimiters, not just the space character. Hopefully I'm doing the right thing here.
