### PR TITLE
Fix potential leak based on analyzer advice

### DIFF
--- a/Classes/NSArray+ObjectiveSugar.m
+++ b/Classes/NSArray+ObjectiveSugar.m
@@ -168,7 +168,7 @@
 }
 
 - (NSArray *)sortBy:(NSString*)key; {
-    NSSortDescriptor *descriptor = [[NSSortDescriptor alloc] initWithKey:key ascending:YES];
+    NSSortDescriptor *descriptor = [[[NSSortDescriptor alloc] initWithKey:key ascending:YES] autorelease];
     return [self sortedArrayUsingDescriptors:@[descriptor]];
 }
 


### PR DESCRIPTION
```
Analyzer Warnings:

  0) Pods/ObjectiveSugar/Classes/NSArray+ObjectiveSugar.m:172:12: Potential leak of an object stored into 'descriptor':
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
169 
170 - (NSArray *)sortBy:(NSString*)key; {
171     NSSortDescriptor *descriptor = [[NSSortDescriptor alloc] initWithKey:key ascending:YES];
172     return [self sortedArrayUsingDescriptors:@[descriptor]];
        ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
173 }
174 <rest>

Pods/ObjectiveSugar/Classes/NSArray+ObjectiveSugar.m:171:36: Method returns an Objective-C object with a +1 retain count
Pods/ObjectiveSugar/Classes/NSArray+ObjectiveSugar.m:172:12: Object leaked: object allocated and stored into 'descriptor' is not referenced later in this execution path and has a retain count of +1
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

** ANALYZE FAILED ** (13137 ms)
```
