### PR TITLE
Fix for bug in [NSMutableArray keepIf:]

### DIFF
--- a/Classes/NSMutableArray+ObjectiveSugar.m
+++ b/Classes/NSMutableArray+ObjectiveSugar.m
@@ -51,13 +51,16 @@
 }
 
 - (NSArray *)keepIf:(BOOL (^)(id object))block {
-    for (NSUInteger i = 0; i < self.count; i++) {
+    for (NSUInteger i = 0; i < self.count; ) {
         id object = self[i];
         if (block(object) == NO) {
             [self removeObject:object];
         }
+        else {
+            i++;
+        }
     }
-    
+
     return self;
 }
 


### PR DESCRIPTION
The following test will fail when two adjacent values do not meet the condition as it will skip an element:

```
NSMutableArray *ma = [NSMutableArray arrayWithObjects:@1, @3, @10, nil];

[ma keepIf:^BOOL(id object) {
    return [object intValue] > 5;
}];

if ( ![ma isEqual:@[@10]] )
       XCTFail(@"fail …
```

The alternative is to go through the array in reverse order though in a way this is less intuitive.
