### PR TITLE
Add slather for test coverage

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -1,0 +1,3 @@
+coverage_service: coveralls
+source_directory: Classes/
+xcodeproj: Example/ObjectiveSugar.xcodeproj

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: objective-c
 
 before_install:
+  - gem install slather --no-rdoc --no-ri --no-document --quiet
   - cd Example
 
 install: make install
 
 script: make ci
 
+after_success:
+  - cd ../ 
+  - slather

--- a/Example/ObjectiveSugar.xcodeproj/project.pbxproj
+++ b/Example/ObjectiveSugar.xcodeproj/project.pbxproj
@@ -1,556 +1,1267 @@
-// !$*UTF8*$!
-{
-	archiveVersion = 1;
-	classes = {
-	};
-	objectVersion = 46;
-	objects = {
-
-/* Begin PBXBuildFile section */
-		11566D315A504F04BFD15074 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 32DEFD3FCB544122AD940C8F /* libPods.a */; };
-		8969012D173C0E4C00B403D2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8969012C173C0E4C00B403D2 /* UIKit.framework */; };
-		8969012F173C0E4C00B403D2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8969012E173C0E4C00B403D2 /* Foundation.framework */; };
-		89690131173C0E4C00B403D2 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 89690130173C0E4C00B403D2 /* CoreGraphics.framework */; };
-		89690137173C0E4C00B403D2 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 89690135173C0E4C00B403D2 /* InfoPlist.strings */; };
-		89690139173C0E4C00B403D2 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 89690138173C0E4C00B403D2 /* main.m */; };
-		8969013D173C0E4C00B403D2 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 8969013C173C0E4C00B403D2 /* AppDelegate.m */; };
-		8969013F173C0E4C00B403D2 /* Default.png in Resources */ = {isa = PBXBuildFile; fileRef = 8969013E173C0E4C00B403D2 /* Default.png */; };
-		89690141173C0E4C00B403D2 /* Default@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 89690140173C0E4C00B403D2 /* Default@2x.png */; };
-		89690143173C0E4C00B403D2 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 89690142173C0E4C00B403D2 /* Default-568h@2x.png */; };
-		8969014B173C0E4C00B403D2 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8969014A173C0E4C00B403D2 /* SenTestingKit.framework */; };
-		8969014C173C0E4C00B403D2 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8969012C173C0E4C00B403D2 /* UIKit.framework */; };
-		8969014D173C0E4C00B403D2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8969012E173C0E4C00B403D2 /* Foundation.framework */; };
-		89690155173C0E4C00B403D2 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 89690153173C0E4C00B403D2 /* InfoPlist.strings */; };
-		89690168173C16A100B403D2 /* CAdditionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89690161173C16A100B403D2 /* CAdditionsTests.m */; };
-		89690169173C16A100B403D2 /* NSArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89690162173C16A100B403D2 /* NSArrayTests.m */; };
-		8969016A173C16A100B403D2 /* NSDictionaryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89690163173C16A100B403D2 /* NSDictionaryTests.m */; };
-		8969016B173C16A100B403D2 /* NSMutableArrayTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89690164173C16A100B403D2 /* NSMutableArrayTests.m */; };
-		8969016C173C16A100B403D2 /* NSNumberTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89690165173C16A100B403D2 /* NSNumberTests.m */; };
-		8969016D173C16A100B403D2 /* NSSetTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89690166173C16A100B403D2 /* NSSetTests.m */; };
-		8969016E173C16A100B403D2 /* NSStringTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 89690167173C16A100B403D2 /* NSStringTests.m */; };
-		A06180063BF14EB68414F45F /* libPods-ObjectiveSugarTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D3D0B2406C7A45249244F020 /* libPods-ObjectiveSugarTests.a */; };
-/* End PBXBuildFile section */
-
-/* Begin PBXContainerItemProxy section */
-		8969014E173C0E4C00B403D2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 89690121173C0E4B00B403D2 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 89690128173C0E4C00B403D2;
-			remoteInfo = ObjectiveSugar;
-		};
-/* End PBXContainerItemProxy section */
-
-/* Begin PBXFileReference section */
-		32DEFD3FCB544122AD940C8F /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		3F587282001D443A984A6180 /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = SOURCE_ROOT; };
-		8189240A1CA64985821AC534 /* Pods-ObjectiveSugarTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ObjectiveSugarTests.xcconfig"; path = "Pods/Pods-ObjectiveSugarTests.xcconfig"; sourceTree = SOURCE_ROOT; };
-		89690129173C0E4C00B403D2 /* ObjectiveSugar.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ObjectiveSugar.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		8969012C173C0E4C00B403D2 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
-		8969012E173C0E4C00B403D2 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
-		89690130173C0E4C00B403D2 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
-		89690134173C0E4C00B403D2 /* ObjectiveSugar-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ObjectiveSugar-Info.plist"; sourceTree = "<group>"; };
-		89690136173C0E4C00B403D2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		89690138173C0E4C00B403D2 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
-		8969013A173C0E4C00B403D2 /* ObjectiveSugar-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ObjectiveSugar-Prefix.pch"; sourceTree = "<group>"; };
-		8969013B173C0E4C00B403D2 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
-		8969013C173C0E4C00B403D2 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
-		8969013E173C0E4C00B403D2 /* Default.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = Default.png; sourceTree = "<group>"; };
-		89690140173C0E4C00B403D2 /* Default@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default@2x.png"; sourceTree = "<group>"; };
-		89690142173C0E4C00B403D2 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
-		89690149173C0E4C00B403D2 /* ObjectiveSugarTests.octest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ObjectiveSugarTests.octest; sourceTree = BUILT_PRODUCTS_DIR; };
-		8969014A173C0E4C00B403D2 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
-		89690152173C0E4C00B403D2 /* ObjectiveSugarTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ObjectiveSugarTests-Info.plist"; sourceTree = "<group>"; };
-		89690154173C0E4C00B403D2 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		89690161173C16A100B403D2 /* CAdditionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CAdditionsTests.m; sourceTree = "<group>"; };
-		89690162173C16A100B403D2 /* NSArrayTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSArrayTests.m; sourceTree = "<group>"; };
-		89690163173C16A100B403D2 /* NSDictionaryTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSDictionaryTests.m; sourceTree = "<group>"; };
-		89690164173C16A100B403D2 /* NSMutableArrayTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSMutableArrayTests.m; sourceTree = "<group>"; };
-		89690165173C16A100B403D2 /* NSNumberTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSNumberTests.m; sourceTree = "<group>"; };
-		89690166173C16A100B403D2 /* NSSetTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSSetTests.m; sourceTree = "<group>"; };
-		89690167173C16A100B403D2 /* NSStringTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSStringTests.m; sourceTree = "<group>"; };
-		D3D0B2406C7A45249244F020 /* libPods-ObjectiveSugarTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ObjectiveSugarTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-/* End PBXFileReference section */
-
-/* Begin PBXFrameworksBuildPhase section */
-		89690126173C0E4C00B403D2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8969012D173C0E4C00B403D2 /* UIKit.framework in Frameworks */,
-				8969012F173C0E4C00B403D2 /* Foundation.framework in Frameworks */,
-				89690131173C0E4C00B403D2 /* CoreGraphics.framework in Frameworks */,
-				11566D315A504F04BFD15074 /* libPods.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		89690145173C0E4C00B403D2 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8969014B173C0E4C00B403D2 /* SenTestingKit.framework in Frameworks */,
-				8969014C173C0E4C00B403D2 /* UIKit.framework in Frameworks */,
-				8969014D173C0E4C00B403D2 /* Foundation.framework in Frameworks */,
-				A06180063BF14EB68414F45F /* libPods-ObjectiveSugarTests.a in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXFrameworksBuildPhase section */
-
-/* Begin PBXGroup section */
-		89690120173C0E4B00B403D2 = {
-			isa = PBXGroup;
-			children = (
-				89690132173C0E4C00B403D2 /* ObjectiveSugar */,
-				89690150173C0E4C00B403D2 /* ObjectiveSugarTests */,
-				8969012B173C0E4C00B403D2 /* Frameworks */,
-				8969012A173C0E4C00B403D2 /* Products */,
-				3F587282001D443A984A6180 /* Pods.xcconfig */,
-				8189240A1CA64985821AC534 /* Pods-ObjectiveSugarTests.xcconfig */,
-			);
-			sourceTree = "<group>";
-		};
-		8969012A173C0E4C00B403D2 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				89690129173C0E4C00B403D2 /* ObjectiveSugar.app */,
-				89690149173C0E4C00B403D2 /* ObjectiveSugarTests.octest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		8969012B173C0E4C00B403D2 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				8969012C173C0E4C00B403D2 /* UIKit.framework */,
-				8969012E173C0E4C00B403D2 /* Foundation.framework */,
-				89690130173C0E4C00B403D2 /* CoreGraphics.framework */,
-				8969014A173C0E4C00B403D2 /* SenTestingKit.framework */,
-				32DEFD3FCB544122AD940C8F /* libPods.a */,
-				D3D0B2406C7A45249244F020 /* libPods-ObjectiveSugarTests.a */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		89690132173C0E4C00B403D2 /* ObjectiveSugar */ = {
-			isa = PBXGroup;
-			children = (
-				8969013B173C0E4C00B403D2 /* AppDelegate.h */,
-				8969013C173C0E4C00B403D2 /* AppDelegate.m */,
-				89690133173C0E4C00B403D2 /* Supporting Files */,
-			);
-			path = ObjectiveSugar;
-			sourceTree = "<group>";
-		};
-		89690133173C0E4C00B403D2 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				89690134173C0E4C00B403D2 /* ObjectiveSugar-Info.plist */,
-				89690135173C0E4C00B403D2 /* InfoPlist.strings */,
-				89690138173C0E4C00B403D2 /* main.m */,
-				8969013A173C0E4C00B403D2 /* ObjectiveSugar-Prefix.pch */,
-				8969013E173C0E4C00B403D2 /* Default.png */,
-				89690140173C0E4C00B403D2 /* Default@2x.png */,
-				89690142173C0E4C00B403D2 /* Default-568h@2x.png */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-		89690150173C0E4C00B403D2 /* ObjectiveSugarTests */ = {
-			isa = PBXGroup;
-			children = (
-				89690161173C16A100B403D2 /* CAdditionsTests.m */,
-				89690162173C16A100B403D2 /* NSArrayTests.m */,
-				89690163173C16A100B403D2 /* NSDictionaryTests.m */,
-				89690164173C16A100B403D2 /* NSMutableArrayTests.m */,
-				89690165173C16A100B403D2 /* NSNumberTests.m */,
-				89690166173C16A100B403D2 /* NSSetTests.m */,
-				89690167173C16A100B403D2 /* NSStringTests.m */,
-				89690151173C0E4C00B403D2 /* Supporting Files */,
-			);
-			path = ObjectiveSugarTests;
-			sourceTree = "<group>";
-		};
-		89690151173C0E4C00B403D2 /* Supporting Files */ = {
-			isa = PBXGroup;
-			children = (
-				89690152173C0E4C00B403D2 /* ObjectiveSugarTests-Info.plist */,
-				89690153173C0E4C00B403D2 /* InfoPlist.strings */,
-			);
-			name = "Supporting Files";
-			sourceTree = "<group>";
-		};
-/* End PBXGroup section */
-
-/* Begin PBXNativeTarget section */
-		89690128173C0E4C00B403D2 /* ObjectiveSugar */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8969015B173C0E4C00B403D2 /* Build configuration list for PBXNativeTarget "ObjectiveSugar" */;
-			buildPhases = (
-				468DABF301EC4EC1A00CC4C2 /* Check Pods Manifest.lock */,
-				89690125173C0E4C00B403D2 /* Sources */,
-				89690126173C0E4C00B403D2 /* Frameworks */,
-				89690127173C0E4C00B403D2 /* Resources */,
-				13656AD991424BF58F43F5B7 /* Copy Pods Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = ObjectiveSugar;
-			productName = ObjectiveSugar;
-			productReference = 89690129173C0E4C00B403D2 /* ObjectiveSugar.app */;
-			productType = "com.apple.product-type.application";
-		};
-		89690148173C0E4C00B403D2 /* ObjectiveSugarTests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8969015E173C0E4C00B403D2 /* Build configuration list for PBXNativeTarget "ObjectiveSugarTests" */;
-			buildPhases = (
-				BC624B20376C4C728DE6A392 /* Check Pods Manifest.lock */,
-				89690144173C0E4C00B403D2 /* Sources */,
-				89690145173C0E4C00B403D2 /* Frameworks */,
-				89690146173C0E4C00B403D2 /* Resources */,
-				89690147173C0E4C00B403D2 /* ShellScript */,
-				174A1F9A81B44DC6B8B6DFD9 /* Copy Pods Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				8969014F173C0E4C00B403D2 /* PBXTargetDependency */,
-			);
-			name = ObjectiveSugarTests;
-			productName = ObjectiveSugarTests;
-			productReference = 89690149173C0E4C00B403D2 /* ObjectiveSugarTests.octest */;
-			productType = "com.apple.product-type.bundle";
-		};
-/* End PBXNativeTarget section */
-
-/* Begin PBXProject section */
-		89690121173C0E4B00B403D2 /* Project object */ = {
-			isa = PBXProject;
-			attributes = {
-				LastUpgradeCheck = 0460;
-				ORGANIZATIONNAME = mneorr.com;
-			};
-			buildConfigurationList = 89690124173C0E4B00B403D2 /* Build configuration list for PBXProject "ObjectiveSugar" */;
-			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
-			hasScannedForEncodings = 0;
-			knownRegions = (
-				en,
-			);
-			mainGroup = 89690120173C0E4B00B403D2;
-			productRefGroup = 8969012A173C0E4C00B403D2 /* Products */;
-			projectDirPath = "";
-			projectRoot = "";
-			targets = (
-				89690128173C0E4C00B403D2 /* ObjectiveSugar */,
-				89690148173C0E4C00B403D2 /* ObjectiveSugarTests */,
-			);
-		};
-/* End PBXProject section */
-
-/* Begin PBXResourcesBuildPhase section */
-		89690127173C0E4C00B403D2 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				89690137173C0E4C00B403D2 /* InfoPlist.strings in Resources */,
-				8969013F173C0E4C00B403D2 /* Default.png in Resources */,
-				89690141173C0E4C00B403D2 /* Default@2x.png in Resources */,
-				89690143173C0E4C00B403D2 /* Default-568h@2x.png in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		89690146173C0E4C00B403D2 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				89690155173C0E4C00B403D2 /* InfoPlist.strings in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		13656AD991424BF58F43F5B7 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-resources.sh\"\n";
-		};
-		174A1F9A81B44DC6B8B6DFD9 /* Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Pods-ObjectiveSugarTests-resources.sh\"\n";
-		};
-		468DABF301EC4EC1A00CC4C2 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-		};
-		89690147173C0E4C00B403D2 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
-		};
-		BC624B20376C4C728DE6A392 /* Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Check Pods Manifest.lock";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
-/* Begin PBXSourcesBuildPhase section */
-		89690125173C0E4C00B403D2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				89690139173C0E4C00B403D2 /* main.m in Sources */,
-				8969013D173C0E4C00B403D2 /* AppDelegate.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		89690144173C0E4C00B403D2 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				89690168173C16A100B403D2 /* CAdditionsTests.m in Sources */,
-				89690169173C16A100B403D2 /* NSArrayTests.m in Sources */,
-				8969016A173C16A100B403D2 /* NSDictionaryTests.m in Sources */,
-				8969016B173C16A100B403D2 /* NSMutableArrayTests.m in Sources */,
-				8969016C173C16A100B403D2 /* NSNumberTests.m in Sources */,
-				8969016D173C16A100B403D2 /* NSSetTests.m in Sources */,
-				8969016E173C16A100B403D2 /* NSStringTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-/* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		8969014F173C0E4C00B403D2 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 89690128173C0E4C00B403D2 /* ObjectiveSugar */;
-			targetProxy = 8969014E173C0E4C00B403D2 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
-/* Begin PBXVariantGroup section */
-		89690135173C0E4C00B403D2 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				89690136173C0E4C00B403D2 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-		89690153173C0E4C00B403D2 /* InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				89690154173C0E4C00B403D2 /* en */,
-			);
-			name = InfoPlist.strings;
-			sourceTree = "<group>";
-		};
-/* End PBXVariantGroup section */
-
-/* Begin XCBuildConfiguration section */
-		89690159173C0E4C00B403D2 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
-				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = iphoneos;
-			};
-			name = Debug;
-		};
-		8969015A173C0E4C00B403D2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 6.1;
-				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
-				SDKROOT = iphoneos;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		8969015C173C0E4C00B403D2 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3F587282001D443A984A6180 /* Pods.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ObjectiveSugar/ObjectiveSugar-Prefix.pch";
-				INFOPLIST_FILE = "ObjectiveSugar/ObjectiveSugar-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = app;
-			};
-			name = Debug;
-		};
-		8969015D173C0E4C00B403D2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3F587282001D443A984A6180 /* Pods.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ObjectiveSugar/ObjectiveSugar-Prefix.pch";
-				INFOPLIST_FILE = "ObjectiveSugar/ObjectiveSugar-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				WRAPPER_EXTENSION = app;
-			};
-			name = Release;
-		};
-		8969015F173C0E4C00B403D2 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8189240A1CA64985821AC534 /* Pods-ObjectiveSugarTests.xcconfig */;
-			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/ObjectiveSugar.app/ObjectiveSugar";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
-					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ObjectiveSugar/ObjectiveSugar-Prefix.pch";
-				INFOPLIST_FILE = "ObjectiveSugarTests/ObjectiveSugarTests-Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Debug;
-		};
-		89690160173C0E4C00B403D2 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8189240A1CA64985821AC534 /* Pods-ObjectiveSugarTests.xcconfig */;
-			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/ObjectiveSugar.app/ObjectiveSugar";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
-					"\"$(DEVELOPER_LIBRARY_DIR)/Frameworks\"",
-				);
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = "ObjectiveSugar/ObjectiveSugar-Prefix.pch";
-				INFOPLIST_FILE = "ObjectiveSugarTests/ObjectiveSugarTests-Info.plist";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUNDLE_LOADER)";
-				WRAPPER_EXTENSION = octest;
-			};
-			name = Release;
-		};
-/* End XCBuildConfiguration section */
-
-/* Begin XCConfigurationList section */
-		89690124173C0E4B00B403D2 /* Build configuration list for PBXProject "ObjectiveSugar" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				89690159173C0E4C00B403D2 /* Debug */,
-				8969015A173C0E4C00B403D2 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		8969015B173C0E4C00B403D2 /* Build configuration list for PBXNativeTarget "ObjectiveSugar" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				8969015C173C0E4C00B403D2 /* Debug */,
-				8969015D173C0E4C00B403D2 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		8969015E173C0E4C00B403D2 /* Build configuration list for PBXNativeTarget "ObjectiveSugarTests" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				8969015F173C0E4C00B403D2 /* Debug */,
-				89690160173C0E4C00B403D2 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-/* End XCConfigurationList section */
-	};
-	rootObject = 89690121173C0E4B00B403D2 /* Project object */;
-}
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>archiveVersion</key>
+	<string>1</string>
+	<key>classes</key>
+	<dict/>
+	<key>objectVersion</key>
+	<string>46</string>
+	<key>objects</key>
+	<dict>
+		<key>11566D315A504F04BFD15074</key>
+		<dict>
+			<key>fileRef</key>
+			<string>32DEFD3FCB544122AD940C8F</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>13656AD991424BF58F43F5B7</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Pods-resources.sh"
+</string>
+		</dict>
+		<key>174A1F9A81B44DC6B8B6DFD9</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Copy Pods Resources</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>"${SRCROOT}/Pods/Pods-ObjectiveSugarTests-resources.sh"
+</string>
+		</dict>
+		<key>32DEFD3FCB544122AD940C8F</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>libPods.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>3F587282001D443A984A6180</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Pods.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>468DABF301EC4EC1A00CC4C2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+		</dict>
+		<key>8189240A1CA64985821AC534</key>
+		<dict>
+			<key>includeInIndex</key>
+			<string>1</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.xcconfig</string>
+			<key>name</key>
+			<string>Pods-ObjectiveSugarTests.xcconfig</string>
+			<key>path</key>
+			<string>Pods/Pods-ObjectiveSugarTests.xcconfig</string>
+			<key>sourceTree</key>
+			<string>SOURCE_ROOT</string>
+		</dict>
+		<key>89690120173C0E4B00B403D2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>89690132173C0E4C00B403D2</string>
+				<string>89690150173C0E4C00B403D2</string>
+				<string>8969012B173C0E4C00B403D2</string>
+				<string>8969012A173C0E4C00B403D2</string>
+				<string>3F587282001D443A984A6180</string>
+				<string>8189240A1CA64985821AC534</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690121173C0E4B00B403D2</key>
+		<dict>
+			<key>attributes</key>
+			<dict>
+				<key>LastUpgradeCheck</key>
+				<string>0460</string>
+				<key>ORGANIZATIONNAME</key>
+				<string>mneorr.com</string>
+			</dict>
+			<key>buildConfigurationList</key>
+			<string>89690124173C0E4B00B403D2</string>
+			<key>compatibilityVersion</key>
+			<string>Xcode 3.2</string>
+			<key>developmentRegion</key>
+			<string>English</string>
+			<key>hasScannedForEncodings</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXProject</string>
+			<key>knownRegions</key>
+			<array>
+				<string>en</string>
+			</array>
+			<key>mainGroup</key>
+			<string>89690120173C0E4B00B403D2</string>
+			<key>productRefGroup</key>
+			<string>8969012A173C0E4C00B403D2</string>
+			<key>projectDirPath</key>
+			<string></string>
+			<key>projectReferences</key>
+			<array/>
+			<key>projectRoot</key>
+			<string></string>
+			<key>targets</key>
+			<array>
+				<string>89690128173C0E4C00B403D2</string>
+				<string>89690148173C0E4C00B403D2</string>
+			</array>
+		</dict>
+		<key>89690124173C0E4B00B403D2</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>89690159173C0E4C00B403D2</string>
+				<string>8969015A173C0E4C00B403D2</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>89690125173C0E4C00B403D2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>89690139173C0E4C00B403D2</string>
+				<string>8969013D173C0E4C00B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>89690126173C0E4C00B403D2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>8969012D173C0E4C00B403D2</string>
+				<string>8969012F173C0E4C00B403D2</string>
+				<string>89690131173C0E4C00B403D2</string>
+				<string>11566D315A504F04BFD15074</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>89690127173C0E4C00B403D2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>89690137173C0E4C00B403D2</string>
+				<string>8969013F173C0E4C00B403D2</string>
+				<string>89690141173C0E4C00B403D2</string>
+				<string>89690143173C0E4C00B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>89690128173C0E4C00B403D2</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>8969015B173C0E4C00B403D2</string>
+			<key>buildPhases</key>
+			<array>
+				<string>468DABF301EC4EC1A00CC4C2</string>
+				<string>89690125173C0E4C00B403D2</string>
+				<string>89690126173C0E4C00B403D2</string>
+				<string>89690127173C0E4C00B403D2</string>
+				<string>13656AD991424BF58F43F5B7</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>ObjectiveSugar</string>
+			<key>productName</key>
+			<string>ObjectiveSugar</string>
+			<key>productReference</key>
+			<string>89690129173C0E4C00B403D2</string>
+			<key>productType</key>
+			<string>com.apple.product-type.application</string>
+		</dict>
+		<key>89690129173C0E4C00B403D2</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.application</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>ObjectiveSugar.app</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>8969012A173C0E4C00B403D2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>89690129173C0E4C00B403D2</string>
+				<string>89690149173C0E4C00B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Products</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8969012B173C0E4C00B403D2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>8969012C173C0E4C00B403D2</string>
+				<string>8969012E173C0E4C00B403D2</string>
+				<string>89690130173C0E4C00B403D2</string>
+				<string>8969014A173C0E4C00B403D2</string>
+				<string>32DEFD3FCB544122AD940C8F</string>
+				<string>D3D0B2406C7A45249244F020</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Frameworks</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8969012C173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>UIKit.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/UIKit.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>8969012D173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8969012C173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8969012E173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>Foundation.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/Foundation.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>8969012F173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8969012E173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>89690130173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>CoreGraphics.framework</string>
+			<key>path</key>
+			<string>System/Library/Frameworks/CoreGraphics.framework</string>
+			<key>sourceTree</key>
+			<string>SDKROOT</string>
+		</dict>
+		<key>89690131173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690130173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>89690132173C0E4C00B403D2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>8969013B173C0E4C00B403D2</string>
+				<string>8969013C173C0E4C00B403D2</string>
+				<string>89690133173C0E4C00B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>ObjectiveSugar</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690133173C0E4C00B403D2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>89690134173C0E4C00B403D2</string>
+				<string>89690135173C0E4C00B403D2</string>
+				<string>89690138173C0E4C00B403D2</string>
+				<string>8969013A173C0E4C00B403D2</string>
+				<string>8969013E173C0E4C00B403D2</string>
+				<string>89690140173C0E4C00B403D2</string>
+				<string>89690142173C0E4C00B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690134173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>ObjectiveSugar-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690135173C0E4C00B403D2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>89690136173C0E4C00B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690136173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690137173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690135173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>89690138173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>main.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690139173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690138173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8969013A173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>ObjectiveSugar-Prefix.pch</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8969013B173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.h</string>
+			<key>path</key>
+			<string>AppDelegate.h</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8969013C173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>AppDelegate.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8969013D173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8969013C173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8969013E173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>image.png</string>
+			<key>path</key>
+			<string>Default.png</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>8969013F173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8969013E173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>89690140173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>image.png</string>
+			<key>path</key>
+			<string>Default@2x.png</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690141173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690140173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>89690142173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>image.png</string>
+			<key>path</key>
+			<string>Default-568h@2x.png</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690143173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690142173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>89690144173C0E4C00B403D2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>89690168173C16A100B403D2</string>
+				<string>89690169173C16A100B403D2</string>
+				<string>8969016A173C16A100B403D2</string>
+				<string>8969016B173C16A100B403D2</string>
+				<string>8969016C173C16A100B403D2</string>
+				<string>8969016D173C16A100B403D2</string>
+				<string>8969016E173C16A100B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXSourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>89690145173C0E4C00B403D2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>8969014B173C0E4C00B403D2</string>
+				<string>8969014C173C0E4C00B403D2</string>
+				<string>8969014D173C0E4C00B403D2</string>
+				<string>A06180063BF14EB68414F45F</string>
+			</array>
+			<key>isa</key>
+			<string>PBXFrameworksBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>89690146173C0E4C00B403D2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array>
+				<string>89690155173C0E4C00B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXResourcesBuildPhase</string>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+		</dict>
+		<key>89690147173C0E4C00B403D2</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string># Run the unit tests in this test bundle.
+"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests"
+</string>
+		</dict>
+		<key>89690148173C0E4C00B403D2</key>
+		<dict>
+			<key>buildConfigurationList</key>
+			<string>8969015E173C0E4C00B403D2</string>
+			<key>buildPhases</key>
+			<array>
+				<string>BC624B20376C4C728DE6A392</string>
+				<string>89690144173C0E4C00B403D2</string>
+				<string>89690145173C0E4C00B403D2</string>
+				<string>89690146173C0E4C00B403D2</string>
+				<string>89690147173C0E4C00B403D2</string>
+				<string>174A1F9A81B44DC6B8B6DFD9</string>
+			</array>
+			<key>buildRules</key>
+			<array/>
+			<key>dependencies</key>
+			<array>
+				<string>8969014F173C0E4C00B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXNativeTarget</string>
+			<key>name</key>
+			<string>ObjectiveSugarTests</string>
+			<key>productName</key>
+			<string>ObjectiveSugarTests</string>
+			<key>productReference</key>
+			<string>89690149173C0E4C00B403D2</string>
+			<key>productType</key>
+			<string>com.apple.product-type.bundle</string>
+		</dict>
+		<key>89690149173C0E4C00B403D2</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>wrapper.cfbundle</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>ObjectiveSugarTests.octest</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+		<key>8969014A173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>wrapper.framework</string>
+			<key>name</key>
+			<string>SenTestingKit.framework</string>
+			<key>path</key>
+			<string>Library/Frameworks/SenTestingKit.framework</string>
+			<key>sourceTree</key>
+			<string>DEVELOPER_DIR</string>
+		</dict>
+		<key>8969014B173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8969014A173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8969014C173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8969012C173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8969014D173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>8969012E173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8969014E173C0E4C00B403D2</key>
+		<dict>
+			<key>containerPortal</key>
+			<string>89690121173C0E4B00B403D2</string>
+			<key>isa</key>
+			<string>PBXContainerItemProxy</string>
+			<key>proxyType</key>
+			<string>1</string>
+			<key>remoteGlobalIDString</key>
+			<string>89690128173C0E4C00B403D2</string>
+			<key>remoteInfo</key>
+			<string>ObjectiveSugar</string>
+		</dict>
+		<key>8969014F173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXTargetDependency</string>
+			<key>target</key>
+			<string>89690128173C0E4C00B403D2</string>
+			<key>targetProxy</key>
+			<string>8969014E173C0E4C00B403D2</string>
+		</dict>
+		<key>89690150173C0E4C00B403D2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>89690161173C16A100B403D2</string>
+				<string>89690162173C16A100B403D2</string>
+				<string>89690163173C16A100B403D2</string>
+				<string>89690164173C16A100B403D2</string>
+				<string>89690165173C16A100B403D2</string>
+				<string>89690166173C16A100B403D2</string>
+				<string>89690167173C16A100B403D2</string>
+				<string>89690151173C0E4C00B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>path</key>
+			<string>ObjectiveSugarTests</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690151173C0E4C00B403D2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>89690152173C0E4C00B403D2</string>
+				<string>89690153173C0E4C00B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXGroup</string>
+			<key>name</key>
+			<string>Supporting Files</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690152173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.xml</string>
+			<key>path</key>
+			<string>ObjectiveSugarTests-Info.plist</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690153173C0E4C00B403D2</key>
+		<dict>
+			<key>children</key>
+			<array>
+				<string>89690154173C0E4C00B403D2</string>
+			</array>
+			<key>isa</key>
+			<string>PBXVariantGroup</string>
+			<key>name</key>
+			<string>InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690154173C0E4C00B403D2</key>
+		<dict>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>text.plist.strings</string>
+			<key>name</key>
+			<string>en</string>
+			<key>path</key>
+			<string>en.lproj/InfoPlist.strings</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690155173C0E4C00B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690153173C0E4C00B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>89690159173C0E4C00B403D2</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>NO</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_DYNAMIC_NO_PIC</key>
+				<string>NO</string>
+				<key>GCC_GENERATE_TEST_COVERAGE_FILES</key>
+				<string>YES</string>
+				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
+				<string>YES</string>
+				<key>GCC_OPTIMIZATION_LEVEL</key>
+				<string>0</string>
+				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
+				<array>
+					<string>DEBUG=1</string>
+					<string>$(inherited)</string>
+				</array>
+				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
+				<string>NO</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>6.1</string>
+				<key>ONLY_ACTIVE_ARCH</key>
+				<string>YES</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>8969015A173C0E4C00B403D2</key>
+		<dict>
+			<key>buildSettings</key>
+			<dict>
+				<key>ALWAYS_SEARCH_USER_PATHS</key>
+				<string>NO</string>
+				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
+				<string>gnu++0x</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
+				<key>CLANG_ENABLE_OBJC_ARC</key>
+				<string>YES</string>
+				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_EMPTY_BODY</key>
+				<string>YES</string>
+				<key>CLANG_WARN_ENUM_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN_INT_CONVERSION</key>
+				<string>YES</string>
+				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
+				<string>YES</string>
+				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
+				<string>iPhone Developer</string>
+				<key>COPY_PHASE_STRIP</key>
+				<string>YES</string>
+				<key>GCC_C_LANGUAGE_STANDARD</key>
+				<string>gnu99</string>
+				<key>GCC_GENERATE_TEST_COVERAGE_FILES</key>
+				<string>YES</string>
+				<key>GCC_INSTRUMENT_PROGRAM_FLOW_ARCS</key>
+				<string>YES</string>
+				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
+				<string>YES</string>
+				<key>GCC_WARN_UNUSED_VARIABLE</key>
+				<string>YES</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>6.1</string>
+				<key>OTHER_CFLAGS</key>
+				<string>-DNS_BLOCK_ASSERTIONS=1</string>
+				<key>SDKROOT</key>
+				<string>iphoneos</string>
+				<key>VALIDATE_PRODUCT</key>
+				<string>YES</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>8969015B173C0E4C00B403D2</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>8969015C173C0E4C00B403D2</string>
+				<string>8969015D173C0E4C00B403D2</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>8969015C173C0E4C00B403D2</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>3F587282001D443A984A6180</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY</key>
+				<string>iPhone Developer</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>ObjectiveSugar/ObjectiveSugar-Prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>ObjectiveSugar/ObjectiveSugar-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>4.3</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>app</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>8969015D173C0E4C00B403D2</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>3F587282001D443A984A6180</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>CODE_SIGN_IDENTITY</key>
+				<string>iPhone Developer</string>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>ObjectiveSugar/ObjectiveSugar-Prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>ObjectiveSugar/ObjectiveSugar-Info.plist</string>
+				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
+				<string>4.3</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>app</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>8969015E173C0E4C00B403D2</key>
+		<dict>
+			<key>buildConfigurations</key>
+			<array>
+				<string>8969015F173C0E4C00B403D2</string>
+				<string>89690160173C0E4C00B403D2</string>
+			</array>
+			<key>defaultConfigurationIsVisible</key>
+			<string>0</string>
+			<key>defaultConfigurationName</key>
+			<string>Release</string>
+			<key>isa</key>
+			<string>XCConfigurationList</string>
+		</dict>
+		<key>8969015F173C0E4C00B403D2</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>8189240A1CA64985821AC534</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>BUNDLE_LOADER</key>
+				<string>$(BUILT_PRODUCTS_DIR)/ObjectiveSugar.app/ObjectiveSugar</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>"$(SDKROOT)/Developer/Library/Frameworks"</string>
+					<string>"$(DEVELOPER_LIBRARY_DIR)/Frameworks"</string>
+				</array>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>ObjectiveSugar/ObjectiveSugar-Prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>ObjectiveSugarTests/ObjectiveSugarTests-Info.plist</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>TEST_HOST</key>
+				<string>$(BUNDLE_LOADER)</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Debug</string>
+		</dict>
+		<key>89690160173C0E4C00B403D2</key>
+		<dict>
+			<key>baseConfigurationReference</key>
+			<string>8189240A1CA64985821AC534</string>
+			<key>buildSettings</key>
+			<dict>
+				<key>BUNDLE_LOADER</key>
+				<string>$(BUILT_PRODUCTS_DIR)/ObjectiveSugar.app/ObjectiveSugar</string>
+				<key>FRAMEWORK_SEARCH_PATHS</key>
+				<array>
+					<string>$(inherited)</string>
+					<string>"$(SDKROOT)/Developer/Library/Frameworks"</string>
+					<string>"$(DEVELOPER_LIBRARY_DIR)/Frameworks"</string>
+				</array>
+				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
+				<string>YES</string>
+				<key>GCC_PREFIX_HEADER</key>
+				<string>ObjectiveSugar/ObjectiveSugar-Prefix.pch</string>
+				<key>INFOPLIST_FILE</key>
+				<string>ObjectiveSugarTests/ObjectiveSugarTests-Info.plist</string>
+				<key>PRODUCT_NAME</key>
+				<string>$(TARGET_NAME)</string>
+				<key>TEST_HOST</key>
+				<string>$(BUNDLE_LOADER)</string>
+				<key>WRAPPER_EXTENSION</key>
+				<string>octest</string>
+			</dict>
+			<key>isa</key>
+			<string>XCBuildConfiguration</string>
+			<key>name</key>
+			<string>Release</string>
+		</dict>
+		<key>89690161173C16A100B403D2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>CAdditionsTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690162173C16A100B403D2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>NSArrayTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690163173C16A100B403D2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>NSDictionaryTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690164173C16A100B403D2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>NSMutableArrayTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690165173C16A100B403D2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>NSNumberTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690166173C16A100B403D2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>NSSetTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690167173C16A100B403D2</key>
+		<dict>
+			<key>fileEncoding</key>
+			<string>4</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>lastKnownFileType</key>
+			<string>sourcecode.c.objc</string>
+			<key>path</key>
+			<string>NSStringTests.m</string>
+			<key>sourceTree</key>
+			<string>&lt;group&gt;</string>
+		</dict>
+		<key>89690168173C16A100B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690161173C16A100B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>89690169173C16A100B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690162173C16A100B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8969016A173C16A100B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690163173C16A100B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8969016B173C16A100B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690164173C16A100B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8969016C173C16A100B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690165173C16A100B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8969016D173C16A100B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690166173C16A100B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>8969016E173C16A100B403D2</key>
+		<dict>
+			<key>fileRef</key>
+			<string>89690167173C16A100B403D2</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>A06180063BF14EB68414F45F</key>
+		<dict>
+			<key>fileRef</key>
+			<string>D3D0B2406C7A45249244F020</string>
+			<key>isa</key>
+			<string>PBXBuildFile</string>
+		</dict>
+		<key>BC624B20376C4C728DE6A392</key>
+		<dict>
+			<key>buildActionMask</key>
+			<string>2147483647</string>
+			<key>files</key>
+			<array/>
+			<key>inputPaths</key>
+			<array/>
+			<key>isa</key>
+			<string>PBXShellScriptBuildPhase</string>
+			<key>name</key>
+			<string>Check Pods Manifest.lock</string>
+			<key>outputPaths</key>
+			<array/>
+			<key>runOnlyForDeploymentPostprocessing</key>
+			<string>0</string>
+			<key>shellPath</key>
+			<string>/bin/sh</string>
+			<key>shellScript</key>
+			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
+if [[ $? != 0 ]] ; then
+    cat &lt;&lt; EOM
+error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
+EOM
+    exit 1
+fi
+</string>
+		</dict>
+		<key>D3D0B2406C7A45249244F020</key>
+		<dict>
+			<key>explicitFileType</key>
+			<string>archive.ar</string>
+			<key>includeInIndex</key>
+			<string>0</string>
+			<key>isa</key>
+			<string>PBXFileReference</string>
+			<key>path</key>
+			<string>libPods-ObjectiveSugarTests.a</string>
+			<key>sourceTree</key>
+			<string>BUILT_PRODUCTS_DIR</string>
+		</dict>
+	</dict>
+	<key>rootObject</key>
+	<string>89690121173C0E4B00B403D2</string>
+</dict>
+</plist>

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -5,3 +5,10 @@ pod 'ObjectiveSugar', :path => '../'
 target :ObjectiveSugarTests, :exclusive => true do
   pod 'Kiwi', :inhibit_warnings => true
 end
+
+begin
+  require 'slather'
+  Slather.prepare_pods(self)
+rescue LoadError
+  puts 'Slather has been disabled (not installed).'
+end


### PR DESCRIPTION
Computes test coverage using slather. Allows you to [see what code is tested](https://coveralls.io/builds/909181), and also gives you a cute little badge. Just need to enable the repo at https://coveralls.io

[![Coverage Status](https://coveralls.io/repos/marklarr/ObjectiveSugar/badge.png?branch=master)](https://coveralls.io/r/marklarr/ObjectiveSugar?branch=master)
