### PR TITLE
Check for nil before adding object to array

### DIFF
--- a/Classes/NSMutableArray+ObjectiveSugar.m
+++ b/Classes/NSMutableArray+ObjectiveSugar.m
@@ -12,7 +12,7 @@
 @implementation NSMutableArray (ObjectiveSugar)
 
 - (void)push:(id)object {
-    [self addObject:object];
+    if (object) [self addObject:object];
 }
 
 - (id)pop {


### PR DESCRIPTION
If a nil object is added to an array, it causes an exception and the app will crash. Adding the object only based on a simple check prevents such errors and results in safer code.
