### PR TITLE
Fix warnings

### DIFF
--- a/Classes/NSArray+ObjectiveSugar.h
+++ b/Classes/NSArray+ObjectiveSugar.h
@@ -8,6 +8,8 @@
 
 // For an overview see http://cocoadocs.org/docsets/ObjectiveSugar/
 
+#import <Foundation/Foundation.h>
+
 @interface NSArray (ObjectiveSugar)
 
 /**

--- a/Classes/NSNumber+ObjectiveSugar.m
+++ b/Classes/NSNumber+ObjectiveSugar.m
@@ -16,7 +16,7 @@
 }
 
 - (void)timesWithIndex:(void (^)(NSUInteger))block {
-    for (uint i = 0; i < self.unsignedIntegerValue; i++)
+    for (NSUInteger i = 0; i < self.unsignedIntegerValue; i++)
         block(i);
 }
 

--- a/Classes/NSNumber+ObjectiveSugar.m
+++ b/Classes/NSNumber+ObjectiveSugar.m
@@ -16,7 +16,7 @@
 }
 
 - (void)timesWithIndex:(void (^)(NSUInteger))block {
-    for (int i = 0; i < self.unsignedIntegerValue; i++)
+    for (uint i = 0; i < self.unsignedIntegerValue; i++)
         block(i);
 }
 


### PR DESCRIPTION
Fixes two issues.

1. Vendoring source classes into a project fails as `NSArray+ObjectiveSugar.h` doesn't import `Foundation.h`
2. Warning about comparison of integers of different signs in `NSNumber+ObjectiveSugar.m`