### PR TITLE
Changing method containsString to containsCaseInsensitiveString

### DIFF
--- a/Classes/NSString+ObjectiveSugar.h
+++ b/Classes/NSString+ObjectiveSugar.h
@@ -50,7 +50,7 @@ NSString *NSStringWithFormat(NSString *format, ...) NS_FORMAT_FUNCTION(1,2);
 
  @return YES if 'string' is a substring of the receiver, otherwise NO
  */
-- (BOOL)containsString:(NSString *)string;
+- (BOOL)containsCaseInsensitiveString:(NSString *)string;
 
 
 /**

--- a/Classes/NSString+ObjectiveSugar.m
+++ b/Classes/NSString+ObjectiveSugar.m
@@ -55,7 +55,7 @@ NSString *NSStringWithFormat(NSString *formatString, ...) {
     return [upperCamelCase stringByReplacingCharactersInRange:NSMakeRange(0, 1) withString:firstLetter.lowercaseString];
 }
 
-- (BOOL)containsString:(NSString *) string {
+- (BOOL)containsCaseInsensitiveString:(NSString *) string {
     NSRange range = [self rangeOfString:string options:NSCaseInsensitiveSearch];
     return range.location != NSNotFound;
 }


### PR DESCRIPTION
containsString was added in iOS8 and this may collide with the
native implementation.
